### PR TITLE
Add support clutter's osx backend

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,17 +32,6 @@ AC_LIBTOOL_WIN32_DLL
 
 AC_CANONICAL_HOST
 
-AC_MSG_CHECKING([for Win32 host])
-case "$host" in
-  *-*-mingw*)
-    os_win32=yes
-    ;;
-  *)
-    os_win32=no
-    ;;
-esac
-AC_MSG_RESULT([$os_win32])
-
 GST_0_10_REQS=0.10.20
 GST_PBUTILS=0.10.30
 CLUTTER_REQS=1.2.0
@@ -90,15 +79,27 @@ PKG_CHECK_MODULES(GIO, gio-2.0 >= $GIO_REQUIRED)
 AC_SUBST(GIO_CFLAGS)
 AC_SUBST(GIO_LIBS)
 
-if test "$os_win32" = "xyes"; then
-  PKG_CHECK_MODULES(CLUTTER_WIN32, clutter-win32-1.0,
+case "$host" in
+  *-*-mingw*|*-*-cygwin*)
+    PKG_CHECK_MODULES(CLUTTER_WIN32, clutter-win32-1.0,
       [AC_DEFINE(HAVE_WIN32, 1, [Define if Clutter Win32 is available.])],
       [])
-else
-  PKG_CHECK_MODULES(CLUTTER_X11, clutter-x11-1.0,
+    ;;
+  *-*-darwin*)
+    PKG_CHECK_MODULES(CLUTTER_OSX, clutter-osx-1.0,
+      [AC_DEFINE(HAVE_OSX, 1, [Define if Clutter OSX is available.])],
+      [
+        PKG_CHECK_MODULES(CLUTTER_X11, clutter-x11-1.0,
+          [AC_DEFINE(HAVE_X11, 1, [Define if Clutter X11 is available.])],
+          [])
+      ])
+    ;;
+  *)
+    PKG_CHECK_MODULES(CLUTTER_X11, clutter-x11-1.0,
       [AC_DEFINE(HAVE_X11, 1, [Define if Clutter X11 is available.])],
       [])
-fi
+    ;;
+esac
 
 PKG_CHECK_MODULES(XTEST, xtst,
     [AC_DEFINE(HAVE_XTEST, 1, [Define if XTest is available.])], [true])


### PR DESCRIPTION
In osx, we should first check for clutter-osx and fallback to clutter-x11 if not found.
